### PR TITLE
Select panic bugfix

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -101,8 +101,10 @@ impl Iterator for Select {
 
             let pulse = {
                 let mut guard = self.inner.lock().unwrap();
-                if let Some(x) = guard.ready.pop() {
-                    return Some(self.signals.remove(&x).map(|x| x.disarm()).unwrap());
+                while let Some(x) = guard.ready.pop() {
+                    if let Some(x) = self.signals.remove(&x) {
+                        return Some(x.disarm());
+                    }
                 }
                 let (pulse, t) = Signal::new();
                 guard.trigger = Some(t);


### PR DESCRIPTION
I'm not very familiar with the codebase, but it seems like calling `select.remove()` after an item already existed in `inner.ready` would cause it to panic (and subsequently poison the `inner` mutex, causing everything to explode).