### PR TITLE
Replace time with std::time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ homepage = "https://github.com/csherratt/pulse"
 
 [dependencies]
 atom = "0.3"
-time = "0.1"
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -526,7 +526,7 @@ impl Scheduler for ThreadScheduler {
                 if elapsed > ms {
                     return Err(TimeoutError::Timeout);
                 }
-                thread::park_timeout(elapsed);
+                thread::park_timeout(ms - elapsed);
             }
             signal.remove_from_waitlist(id);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,7 +523,7 @@ impl Scheduler for ThreadScheduler {
             let id = signal.add_to_waitlist(Waiting::thread());
             if signal.is_pending() {
                 let elapsed = start.elapsed();
-                if elapsed > end {
+                if elapsed > ms {
                     return Err(TimeoutError::Timeout);
                 }
                 thread::park_timeout(elapsed);


### PR DESCRIPTION
A semver change would be to modify wait_timeout_ms to wait_timeout & take a Duration instead of a u32 ms

Wrote PR thru Github, feel free to squash